### PR TITLE
[feat] 헤더 네비게이션 추가, 사용하지 않는 탭 제거

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -26,7 +26,13 @@
 		routes={{
 			'/': Search,
 			'/summoner/:id': Main,
-			'/summoner/champions/:id': Main,
+			// '/summoner/champions/:id': Main, // 챔피언 탭 미사용으로 인한 주석 처리
 		}}
 	/>
 {/await}
+
+<style>
+	:global(body) {
+		margin: 0;
+	}
+</style>

--- a/src/components/headers/HeaderNav.svelte
+++ b/src/components/headers/HeaderNav.svelte
@@ -17,7 +17,7 @@
 	</div>
 	<div class="search">
 		<!-- TODO: OP.GG Search 컴포넌트 CSS으로 수정 필요 -->
-		<AutocompleteInput />
+		<!-- <AutocompleteInput /> -->
 	</div>
 </div>
 
@@ -26,7 +26,7 @@
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
-		height: 72px;
+		height: 48px;
 		background-color: #5383e8;
 	}
 	.logo {

--- a/src/components/headers/HeaderNav.svelte
+++ b/src/components/headers/HeaderNav.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import AutocompleteInput from '../search/AutocompleteInput.svelte';
+</script>
+
+<div class="headerTop">
+	<div class="logo">
+		<h1>
+			<a href="/">
+				<img
+					src="https://s-lol-web.op.gg/images/icon/opgglogo.svg?v=1653487405752"
+					width="65"
+					alt="OP.GG"
+					height="16"
+				/>
+			</a>
+		</h1>
+	</div>
+	<div class="search">
+		<!-- TODO: OP.GG Search 컴포넌트 CSS으로 수정 필요 -->
+		<AutocompleteInput />
+	</div>
+</div>
+
+<style>
+	.headerTop {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		height: 72px;
+		background-color: #5383e8;
+	}
+	.logo {
+		height: 40px;
+	}
+	.logo h1 {
+		width: 98px;
+		height: 40px;
+		background-color: #5383e8;
+		margin: 0;
+	}
+	.logo h1 a {
+		width: 100%;
+		height: 100%;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+	.search {
+		position: absolute;
+		top: 8px;
+		right: 24px;
+		z-index: 1;
+	}
+</style>

--- a/src/components/headers/index.ts
+++ b/src/components/headers/index.ts
@@ -1,1 +1,2 @@
 export { default as HeaderTitle } from './HeaderTitle.svelte';
+export { default as HeaderNav } from './HeaderNav.svelte';

--- a/src/components/left-side/OverviewStats/MoreButton.svelte
+++ b/src/components/left-side/OverviewStats/MoreButton.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-	import { location, push } from 'svelte-spa-router';
+	// import { location, push } from 'svelte-spa-router';
 
 	const handleClick = () => {
+		/* 챔피언 탭 미사용으로 인한 주석 처리
 		const path = $location as string;
 		const userName: string = path.split('/')?.pop() || '';
 		const newPath = `/summoner/champions/${userName}`;
@@ -9,7 +10,7 @@
 			window.location.reload();
 		} else {
 			return push(newPath);
-		}
+		}*/
 	};
 </script>
 

--- a/src/components/main/Main.svelte
+++ b/src/components/main/Main.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-	import { HeaderTitle } from '../headers';
+	import { HeaderTitle, HeaderNav } from '../headers';
 	import { TabList } from '../tabs';
 </script>
 
 <main>
+	<HeaderNav />
 	<HeaderTitle />
 	<TabList />
 </main>

--- a/src/components/right-side/GameDetail/GameDetail.svelte
+++ b/src/components/right-side/GameDetail/GameDetail.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
 	import type { Match } from '../../../schema/api/matches';
-	import type { GameDetailTab } from '../types';
-	import GameDetailTabs from './GameDetailTabs.svelte';
-	import { GameDetailBuild } from './build';
-	import { GameDetailEtc } from './etc';
-	import { GameDetailTeam } from './team';
+	// import type { GameDetailTab } from '../types';
+	// import GameDetailTabs from './GameDetailTabs.svelte';
+	// import { GameDetailBuild } from './build';
+	// import { GameDetailEtc } from './etc';
+	// import { GameDetailTeam } from './team';
 	import { GameDetailTotal } from './total';
 	import { getMatches } from '../dummy';
 
-	let tabs: GameDetailTab[] = [
+	/*let tabs: GameDetailTab[] = [
 		{ label: '종합', value: 'overview', component: GameDetailTotal },
 		{ label: '팀 분석', value: 'teamAnalysis', component: GameDetailTeam },
 		{ label: '빌드', value: 'builds', component: GameDetailBuild },
 		{ label: 'etc', value: 'gold', component: GameDetailEtc },
-	];
+	];*/
 
 	// TODO: 소환사 아이디 가져오기
 	let summonerId = 'summonerId';
@@ -21,4 +21,5 @@
 	let matches: Match = getMatches();
 </script>
 
-<GameDetailTabs {tabs} {summonerId} {matches} />
+<!-- <GameDetailTabs {tabs} {summonerId} {matches} /> 종합 탭 정보만 보이는 것으로 수정 -->
+<GameDetailTotal {summonerId} {matches} />

--- a/src/components/right-side/GameListTabPanelItem.svelte
+++ b/src/components/right-side/GameListTabPanelItem.svelte
@@ -6,7 +6,7 @@
 	import GameList from './GameList.svelte';
 
 	// TODO: 탭 별 매치 데이터 가져오기
-	$: console.log('게임 타입: ', $selectedPanel);
+	// $: console.log('게임 타입: ', $selectedPanel);
 	let stats: GameAverageStats = getGameAverageStatsDummyData($selectedPanel);
 </script>
 

--- a/src/components/tabs/TabList.svelte
+++ b/src/components/tabs/TabList.svelte
@@ -34,10 +34,12 @@
 <ul>
 	{#each items as item, i}
 		<li class={activeTab === item.activeOption ? `active index-${i}` : `non-active index-${i}`}>
+			<!-- 종합 탭만 사용함에 따라 탭 일괄 미표기
 			<div class="tab" on:click={handleClick(item.activeOption)}>
 				<i class={i === 2 ? `icon` : ``} />
 				<span class={i === 2 ? `iconspan` : ``}>{item.label}</span>
-			</div>
+			</div> 
+			-->
 		</li>
 	{/each}
 </ul>

--- a/src/components/tabs/TabList.svelte
+++ b/src/components/tabs/TabList.svelte
@@ -16,6 +16,7 @@
 			component: TotalTab,
 			activeOption: 'total',
 		},
+		/* 챔피언, 인게임 탭 미사용으로 인한 주석 처리
 		{
 			label: '챔피언',
 			component: ChampionTab,
@@ -25,7 +26,7 @@
 			label: '인게임 정보',
 			component: ChampionTab,
 			activeOption: 'ingame',
-		},
+		},*/
 	];
 	const handleClick = (selectedTab: string) => () => (activeTab = selectedTab);
 </script>
@@ -42,7 +43,7 @@
 </ul>
 {#each items as item}
 	{#if activeTab == item.activeOption}
-		<div class="box">
+		<div>
 			<svelte:component this={item.component} />
 		</div>
 	{/if}
@@ -105,8 +106,5 @@
 		background-color: transparent;
 		border-bottom-color: #f2f2f2;
 		color: black;
-	}
-	.box {
-		height: 100vh;
 	}
 </style>


### PR DESCRIPTION
<img width="1059" alt="스크린샷 2022-05-29 오전 12 04 29" src="https://user-images.githubusercontent.com/29051383/170831265-c108b596-e5a8-459f-91f8-17103b90c878.png">

- 헤더 네비게이션 추가
- 챔피언 탭 미사용으로 인한 주석 처리. 탭 일괄 미표기 (종합만 표시)
-  매치 상세 정보에서 탭 일괄 미표기 (종합만 표시)